### PR TITLE
faviconリクエストでCookieの値が変わりstateの検証に落ちる問題の修正

### DIFF
--- a/answer/templates/callback.html
+++ b/answer/templates/callback.html
@@ -6,6 +6,7 @@
 <meta name="description" content="">
 <meta name="author" content="">
 <link rel="stylesheet" href="">
+<link rel="icon" href="data:,">
 </head>
 <body>
 <script>

--- a/answer/templates/error.html
+++ b/answer/templates/error.html
@@ -6,6 +6,7 @@
 <meta name="description" content="">
 <meta name="author" content="">
 <link rel="stylesheet" href="">
+<link rel="icon" href="data:,">
 </head>
 <body>
 <script>

--- a/answer/templates/index.html
+++ b/answer/templates/index.html
@@ -6,6 +6,7 @@
 <meta name="description" content="">
 <meta name="author" content="">
 <link rel="stylesheet" href="">
+<link rel="icon" href="data:,">
 </head>
 <body>
 <script>


### PR DESCRIPTION
## 問題
chromeで動作検証をした際に、
faviconがないため`/favicon.ico`へのリクエストで`/index`へリダイレクトされる

![image](https://user-images.githubusercontent.com/26164869/73660246-23c33800-46db-11ea-8bc4-bda49d3f5e5a.png)

`/index`にてCookieの値が書き換えられるが、redirect_uriのstate値は初回リクエスト時に発行されたもののため、`/callback`でのstate検証に失敗する

Cookieのstate
![image](https://user-images.githubusercontent.com/26164869/73660473-98967200-46db-11ea-90b6-23520f83fda0.png)

RedirectURIのstate
![image](https://user-images.githubusercontent.com/26164869/73660650-f32fce00-46db-11ea-8c8c-02520c0f2ffb.png)

## 対応
https://stackoverflow.com/questions/1321878/how-to-prevent-favicon-ico-requests
こちらを参考にfaviconの設定を行い`/index`へのリダイレクトが行われないようにする

## 動作確認
- [x] chrome（`バージョン: 79.0.3945.130（Official Build） （64 ビット）`）でstateの検証が成功すること